### PR TITLE
improve fix

### DIFF
--- a/src/Command/RegisterChangedSchemasCommand.php
+++ b/src/Command/RegisterChangedSchemasCommand.php
@@ -149,12 +149,13 @@ class RegisterChangedSchemasCommand extends AbstractSchemaCommand
             }
 
             try {
-                $this->schemaRegistryApi->registerNewSchemaVersion($schemaName, $localSchema);
-            } catch (\Throwable $e) {
+                AvroSchema::parse($localSchema);
+            } catch (AvroSchemaParseException $e) {
                 $io->writeln(sprintf('Skipping %s for now because %s', $schemaName, $e->getMessage()));
                 $failed[$schemaName] = $schemaName;
                 continue;
             }
+            $this->schemaRegistryApi->registerNewSchemaVersion($schemaName, $localSchema);
 
             $succeeded[$schemaName] = [
                 'name' => $schemaName,


### PR DESCRIPTION
I would suggest adjusting the previous fix to this, reason being, that the previous logic did:
- make sure Avro was valid according to the Avro specification
- make sure we were able to register the schema

The new logic:
- makes sure we can register the schema
It also relies that any schema registry variant (official schema registry, karapace, redpanda) adhere to the same avro specs without bugs. This is less save and the additional check should be kept imho