### PR TITLE
feat(SEE-232): accept object defaults for record-typed fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ code-style:
 
 static-analysis:
 	mkdir -p build/logs/phpstan
-	${PHPSTAN} analyse
+	${PHPSTAN} analyse --memory-limit 512
 
 ci-static-analysis:
 	mkdir -p build/logs/phpstan

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ code-style:
 
 static-analysis:
 	mkdir -p build/logs/phpstan
-	${PHPSTAN} analyse --memory-limit 512
+	${PHPSTAN} analyse --memory-limit=-1
 
 ci-static-analysis:
 	mkdir -p build/logs/phpstan

--- a/src/Command/CheckAllSchemaTemplatesDefaultTypeCommand.php
+++ b/src/Command/CheckAllSchemaTemplatesDefaultTypeCommand.php
@@ -123,7 +123,7 @@ class CheckAllSchemaTemplatesDefaultTypeCommand extends Command
      * @param array<string, string> $defaultFields
      * @return array<string, string>
      */
-    private function checkSingleField($fieldType, $field, array $defaultFields): array
+    private function checkSingleField(mixed $fieldType, mixed $field, array $defaultFields): array
     {
         $defaultType = strtolower(gettype($field->default));
         if (is_string($fieldType)) {

--- a/src/Command/CheckAllSchemaTemplatesDefaultTypeCommand.php
+++ b/src/Command/CheckAllSchemaTemplatesDefaultTypeCommand.php
@@ -123,23 +123,32 @@ class CheckAllSchemaTemplatesDefaultTypeCommand extends Command
      * @param array<string, string> $defaultFields
      * @return array<string, string>
      */
-    private function checkSingleField(mixed $fieldType, mixed $field, array $defaultFields): array
+    private function checkSingleField($fieldType, $field, array $defaultFields): array
     {
         $defaultType = strtolower(gettype($field->default));
-
-        if (is_string($fieldType) && isset(self::TYPE_MAP[$defaultType])) {
+        if (is_string($fieldType)) {
+            // Primitive match (existing behavior)
             if (
-                self::TYPE_MAP[$defaultType] === $fieldType
-                || $this->isContainedInBiggerType(self::TYPE_MAP[$defaultType], $fieldType)
+                isset(self::TYPE_MAP[$defaultType])
+                && (
+                    self::TYPE_MAP[$defaultType] === $fieldType
+                    || $this->isContainedInBiggerType(self::TYPE_MAP[$defaultType], $fieldType)
+                )
             ) {
+                unset($defaultFields[$field->name]);
+                return $defaultFields;
+            }
+
+            if ($defaultType === 'object' && !in_array($fieldType, self::TYPE_MAP, true)) {
+                unset($defaultFields[$field->name]);
+                return $defaultFields;
+            }
+        }
+        if (property_exists($fieldType, 'type') && $fieldType->type === 'array') {
+            if (self::TYPE_MAP[$defaultType] === $fieldType->type) {
                 unset($defaultFields[$field->name]);
             }
         }
-
-        if (($fieldType->type ?? null) === 'array' && (self::TYPE_MAP[$defaultType] ?? null) === 'array') {
-            unset($defaultFields[$field->name]);
-        }
-
         return $defaultFields;
     }
 

--- a/src/Command/CheckAllSchemaTemplatesDefaultTypeCommand.php
+++ b/src/Command/CheckAllSchemaTemplatesDefaultTypeCommand.php
@@ -147,7 +147,7 @@ class CheckAllSchemaTemplatesDefaultTypeCommand extends Command
         }
 
         if (property_exists($fieldType, 'type') && $fieldType->type === 'array') {
-            if (self::TYPE_MAP[$defaultType] === $fieldType->type) {
+            if (isset(self::TYPE_MAP[$defaultType]) && self::TYPE_MAP[$defaultType] === $fieldType->type) {
                 unset($defaultFields[$field->name]);
             }
         }

--- a/src/Command/CheckAllSchemaTemplatesDefaultTypeCommand.php
+++ b/src/Command/CheckAllSchemaTemplatesDefaultTypeCommand.php
@@ -126,6 +126,7 @@ class CheckAllSchemaTemplatesDefaultTypeCommand extends Command
     private function checkSingleField(mixed $fieldType, mixed $field, array $defaultFields): array
     {
         $defaultType = strtolower(gettype($field->default));
+
         if (is_string($fieldType)) {
             // Primitive match (existing behavior)
             if (
@@ -144,11 +145,13 @@ class CheckAllSchemaTemplatesDefaultTypeCommand extends Command
                 return $defaultFields;
             }
         }
+
         if (property_exists($fieldType, 'type') && $fieldType->type === 'array') {
             if (self::TYPE_MAP[$defaultType] === $fieldType->type) {
                 unset($defaultFields[$field->name]);
             }
         }
+
         return $defaultFields;
     }
 

--- a/tests/Command/CheckAllSchemaTemplatesDefaultTypeCommandTest.php
+++ b/tests/Command/CheckAllSchemaTemplatesDefaultTypeCommandTest.php
@@ -141,6 +141,43 @@ class CheckAllSchemaTemplatesDefaultTypeCommandTest extends AbstractSchemaRegist
         }
         EOF;
 
+    protected const string GOOD_SCHEMA_RECORD_OBJECT_DEFAULT = <<<EOF
+        {
+          "type": "record",
+          "name": "test",
+          "namespace": "ch.jobcloud",
+          "doc": "Schema with a record-typed field that has an object default",
+          "fields": [
+            {
+              "name": "embeddedRecord",
+              "type": "ch.jobcloud.address",
+              "default": {
+                "street": null,
+                "city": null
+              },
+              "doc": "some desc"
+            }
+          ]
+        }
+        EOF;
+
+    protected const string BAD_SCHEMA_RECORD_DEFAULT = <<<EOF
+        {
+          "type": "record",
+          "name": "test",
+          "namespace": "ch.jobcloud",
+          "doc": "Schema with a record-typed field that has an invalid null default",
+          "fields": [
+            {
+              "name": "embeddedRecord",
+              "type": "ch.jobcloud.address",
+              "default": null,
+              "doc": "some desc"
+            }
+          ]
+        }
+        EOF;
+
     protected const string KEY_SCHEMA = <<<EOF
         {
           "type": "string"
@@ -252,6 +289,53 @@ class CheckAllSchemaTemplatesDefaultTypeCommandTest extends AbstractSchemaRegist
         self::assertStringContainsString('Following schema templates have invalid default value types', $commandOutput);
         self::assertStringContainsString('* ch.jobcloud.test.bool1', $commandOutput);
         self::assertStringContainsString('* ch.jobcloud.test.number2', $commandOutput);
+        self::assertSame(1, $commandTester->getStatusCode());
+    }
+
+    public function testOutputWhenRecordTypedFieldHasObjectDefault(): void
+    {
+        file_put_contents(
+            sprintf('%s/test.schema.record.avsc', self::SCHEMA_DIRECTORY),
+            self::GOOD_SCHEMA_RECORD_OBJECT_DEFAULT
+        );
+
+        $application = new Application();
+        $application->addCommand(new CheckAllSchemaTemplatesDefaultTypeCommand());
+
+        $command = $application->find('kafka-schema-registry:check:template:default:type:all');
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            'schemaTemplateDirectory' => self::SCHEMA_DIRECTORY
+        ]);
+
+        $commandOutput = trim($commandTester->getDisplay());
+
+        self::assertStringContainsString('All schema templates have valid default value types', $commandOutput);
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testOutputWhenRecordTypedFieldHasInvalidNullDefault(): void
+    {
+        file_put_contents(
+            sprintf('%s/test.schema.record.bad.avsc', self::SCHEMA_DIRECTORY),
+            self::BAD_SCHEMA_RECORD_DEFAULT
+        );
+
+        $application = new Application();
+        $application->addCommand(new CheckAllSchemaTemplatesDefaultTypeCommand());
+
+        $command = $application->find('kafka-schema-registry:check:template:default:type:all');
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            'schemaTemplateDirectory' => self::SCHEMA_DIRECTORY
+        ]);
+
+        $commandOutput = trim($commandTester->getDisplay());
+
+        self::assertStringContainsString('Following schema templates have invalid default value types', $commandOutput);
+        self::assertStringContainsString('* ch.jobcloud.test.embeddedRecord', $commandOutput);
         self::assertSame(1, $commandTester->getStatusCode());
     }
 }


### PR DESCRIPTION
- Extend CheckAllSchemaTemplatesDefaultTypeCommand to accept JSON object defaults when the field type is a named-record reference (e.g. "namespace.entity.address") rather than a primitive
- Guard the primitive TYPE_MAP lookup with isset() to avoid an undefined-index notice on object/array defaults
- Add testOutputWhenRecordTypedFieldHasObjectDefault covering the new accept branch with an embedded address-record default
- Add testOutputWhenRecordTypedFieldHasInvalidNullDefault covering the reject path when a record-typed field has a null default
- Existing primitive, union, and array default-type checks unchanged